### PR TITLE
Fix java version required by mohist 1.16.5

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Mohist is a Forge server software implementing Bukkit, Spigot and Paper APIs. Th
 You need **java 8**.
 
 ### Mohist 1.16.5 :
-You need a java version between **java 11** and **java 15**.
+You need a java version between **java 11** and **java 16**.
 
 ## About Mohist
 

--- a/install/linux.md
+++ b/install/linux.md
@@ -6,7 +6,7 @@ Requirements
 
 Mohist **1.12.2** requires **[Java 8](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot)**.
 
-Mohist **1.16.5** requires **[Java 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot)**.
+Mohist **1.16.5** requires Java between **[Java 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot)** and  **[Java 16](https://adoptopenjdk.net/?variant=openjdk16&jvmVariant=hotspot)** (**Java 11** stay recommanded).
 
 ---
 Download

--- a/install/windows.md
+++ b/install/windows.md
@@ -6,7 +6,7 @@ Requirements
 
 Mohist **1.12.2** requires **[Java 8](https://adoptopenjdk.net/?variant=openjdk8&jvmVariant=hotspot)**.
 
-Mohist **1.16.5** requires **[Java 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot)**.
+Mohist **1.16.5** requires Java between **[Java 11](https://adoptopenjdk.net/?variant=openjdk11&jvmVariant=hotspot)** and  **[Java 16](https://adoptopenjdk.net/?variant=openjdk16&jvmVariant=hotspot)** (**Java 11** stay recommanded).
 
 ---
 Download


### PR DESCRIPTION
This change say Java 16 like compatible with mohist 1.16.5